### PR TITLE
fix TypeError: __init__() got an unexpected keyword argument 'type' in argparse

### DIFF
--- a/baselines/models_pytorch/mrc_pytorch/convert_tf_checkpoint_to_pytorch.py
+++ b/baselines/models_pytorch/mrc_pytorch/convert_tf_checkpoint_to_pytorch.py
@@ -116,7 +116,6 @@ if __name__ == "__main__":
     parser.add_argument("--is_albert",
                         default=False,
                         action='store_true',
-                        type=bool,
                         help="whether is albert?")
     args = parser.parse_args()
     convert_tf_checkpoint_to_pytorch(args.tf_checkpoint_path,


### PR DESCRIPTION
这个文件里的argparse共用了action='store_true'和type=bool，这个操作会[引起错误](https://stackoverflow.com/questions/33574270/typeerror-init-got-an-unexpected-keyword-argument-type-in-argparse)，所以现在把它去除了。